### PR TITLE
Fixed typo on Catalog from Catelog - line 1580

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -1577,7 +1577,7 @@ map.addLayer(labelLayer);</p>
 		<li>Enter <a href="https://maps.nyc.gov/wmts/1.0.0/?REQUEST=getcapabilities">https://maps.nyc.gov/wmts/1.0.0/?REQUEST=getcapabilities</a> into the <b>URL</b> field of the <b>Add WMTS Server</b> dialog</li>
 		<li>Click the <b>Get Layer</b> button</li> 
 		<li>Click the <b>Ok</b> button to in the <b>Add WMTS Server</b> dialog</li>
-		<li>In the <b>GIS Servers</b> section of <b>Catelog</b> there will now be a <b>Web Map Tile Service - GeoWebCache on maps.nyc.gov</b> choice</li>
+		<li>In the <b>GIS Servers</b> section of <b>Catalog</b> there will now be a <b>Web Map Tile Service - GeoWebCache on maps.nyc.gov</b> choice</li>
 		<li>Expand the <b>Web Map Tile Service - GeoWebCache on maps.nyc.gov</b> choice and drag a layer into the <b>Table of Contents</b></li>
 	</ol>
 	


### PR DESCRIPTION
Simple typo fix on 1580 'Catelog' to 'Catalog' - brought up by user