### PR TITLE
Add 2018 layer to 'then&now' example app

### DIFF
--- a/src/main/webapp/nyc.tsv
+++ b/src/main/webapp/nyc.tsv
@@ -1,6 +1,7 @@
 basemap	NYCTMS	https://maps.nyc.gov/tms/1.0.0/carto/basemap/{z}/{x}/{y}.jpg	0	8	21
 label	NYCTMS	https://maps.nyc.gov/tms/1.0.0/carto/label/{z}/{x}/{y}.png8	0	8	21
 label-lt	NYCTMS	https://maps.nyc.gov/tms/1.0.0/carto/label-lt/{z}/{x}/{y}.png8	0	8	21
+2018	NYCTMS	https://maps.nyc.gov/tms/1.0.0/photo/2018/{z}/{x}/{y}.png8	0	8	21
 2016	NYCTMS	https://maps.nyc.gov/tms/1.0.0/photo/2016/{z}/{x}/{y}.png8	0	8	21
 2014	NYCTMS	https://maps.nyc.gov/tms/1.0.0/photo/2014/{z}/{x}/{y}.png8	0	8	21
 2012	NYCTMS	https://maps.nyc.gov/tms/1.0.0/photo/2012/{z}/{x}/{y}.png8	0	8	21


### PR DESCRIPTION
I noticed that there wasn't an option to show the 2018 base map in the 'Then & Now' example app, so this adds that option.

<img width="951" alt="Screen Shot 2019-07-07 at 9 07 17 PM" src="https://user-images.githubusercontent.com/45028/60776687-f50cc100-a0fb-11e9-8c64-bcb433904b23.png">
